### PR TITLE
Change relative links to name of ipynb file

### DIFF
--- a/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
+++ b/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
@@ -34,9 +34,9 @@
    "source": [
     "First, we will sign into an ArcGIS Enterprise organization to demonstrate these workflows. We can work with Enterprise Sites using the `sites` property of the `GIS` object. \n",
     "\n",
-    "Note: This workflow is for demonstration purposes only. To replicate this, you may have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
+    "> _Note:_ This workflow is for demonstration purposes only. To replicate this, you will have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
     "\n",
-    "The following are examples for working with Initiatives and Events using [ArcGIS Premium](../hub-for-guide-premium) and site and page creation and cloning using [ArcGIS Basic](../hub-for-guide-basic) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
+    "See also these examples for working with Initiatives and Events using [ArcGIS Premium](../hub-premium-guide) and site and page creation and cloning using [ArcGIS Basic](../hub-basic-guide) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
    ]
   },
   {
@@ -578,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* production guide page urls look like this:  for a guide named `name-of-notebook.ipynb`, the resulting html page relative link will be `../name-of-notebook-file1
Merge this PR into this branch and we're good to go!