### PR TITLE
Add top level heading so page is not blank above title bar

### DIFF
--- a/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
+++ b/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
@@ -2,10 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "59b961f6",
+   "metadata": {},
+   "source": [
+    "# The `hub` submodule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6cec2944",
    "metadata": {},
    "source": [
-    "## The `hub` submodule\n",
+    "## Introduction\n",
     "\n",
     "The `hub` submodule within `arcgis.apps` acts as the pythonic interface to [ArcGIS Hub](https://www.esri.com/en-us/arcgis/products/arcgis-hub/overview). It enables automation of several Hub workflows and simplifies the use of the Hub information model by allowing access to Hub objects such as `Initiative`, `Event`, `Site` and `Page`. For tutorials and additional resources on using ArcGIS Hub, see [here](https://www.esri.com/en-us/arcgis/products/arcgis-hub/resources).\n",
     "\n",
@@ -39,14 +47,6 @@
     "* [Hub Basic](../hub-for-guide-basic): Adding site and page, cloning the site to Hub Premium + Basic + Enterprise, Linking and unlinking pages\n",
     "* [Enterprise Sites](../enterprise-sites): Adding site with custom domain, adding page, editing site layout and theme, editing page layout"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e11bafd0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -65,7 +65,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
+++ b/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
@@ -5,7 +5,7 @@
    "id": "59b961f6",
    "metadata": {},
    "source": [
-    "# The `hub` submodule"
+    "# The hub submodule"
    ]
   },
   {
@@ -47,6 +47,14 @@
     "* [Hub Basic](../hub-for-guide-basic): Adding site and page, cloning the site to Hub Premium + Basic + Enterprise, Linking and unlinking pages\n",
     "* [Enterprise Sites](../enterprise-sites): Adding site with custom domain, adding page, editing site layout and theme, editing page layout"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8915e184",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
* if a page doesn't have a markdown cell with a single has to start the notebook, the top of the page appears blank with a purple bar:

|**Before**|**After**|
|---|---|
![image](https://github.com/ManushiM/arcgis-python-api/assets/1399179/2511c1c0-5ce7-45c2-9ee5-2a8a4e0004cd)|![image](https://github.com/ManushiM/arcgis-python-api/assets/1399179/05cd5e76-8f4b-4ed5-a2e9-b5a77a1147c7)

* _**note:**_ The actual text is _The `hub` submodule_. I'm not sure why the local build is not displaying the `hub`.