### PR TITLE
update link for part2 guide to use the relative formatting

### DIFF
--- a/guide/12-enrich-data-with-thematic-information/part5_generate_reports.ipynb
+++ b/guide/12-enrich-data-with-thematic-information/part5_generate_reports.ipynb
@@ -455,14 +455,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we see that Australia has 8 reports available along with their title, categories and the available formats. Details about different categories of reports can be found [here](https://doc.arcgis.com/en/esri-demographics/reference/sample-reports.htm)."
+    "### Creating Reports"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating Reports"
+    "Here we see that Australia has 8 reports available along with their title, categories and the available formats. Details about different categories of reports can be found [here](https://doc.arcgis.com/en/esri-demographics/reference/sample-reports.htm)."
    ]
   },
   {
@@ -473,7 +473,7 @@
     }
    },
    "source": [
-    "The `create_report` method allows you to create many types of high quality reports for a variety of use cases describing the input area. Let's look at some examples of creating reports for some study areas. To learn more about Study Areas, refer to [Enriching Study Areas](part2-where-to-enrich-study-areas) guide.\n",
+    "The `create_report` method allows you to create many types of high quality reports for a variety of use cases describing the input area. Let's look at some examples of creating reports for some study areas. To learn more about Study Areas, refer to [Enriching Study Areas](../part2-where-to-enrich-study-areas) guide.\n",
     "\n",
     "__Note:__ The report `id` must be used as an input in the `create_report()` method to create reports. "
    ]
@@ -879,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.0"
   },
   "livereveal": {
    "scroll": true


### PR DESCRIPTION
Hi @ManushiM 
* the link to the part2 enrichment guide was not working. The Developer Website works in such a way that when you are in a source guide notebook, you can link to another guide notebook using relative formatting(`../<name-of-source-notebook>`). This is really good practice because then if we ever encounter situations like going from 2.3 to 2.4 where we needed to update urls, the links will all still work.